### PR TITLE
API Blueprint support

### DIFF
--- a/Mockingjay.xcodeproj/project.pbxproj
+++ b/Mockingjay.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		274367AE1AA29AED0030C97B /* URITemplate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 274367A91AA29ADA0030C97B /* URITemplate.framework */; };
 		274367B01AA29E510030C97B /* Builders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274367AF1AA29E510030C97B /* Builders.swift */; };
 		274367B21AA29E620030C97B /* BuildersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274367B11AA29E620030C97B /* BuildersTests.swift */; };
+		274367B41AA2AFF50030C97B /* Blueprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274367B31AA2AFF50030C97B /* Blueprint.swift */; };
+		274367B61AA2B0710030C97B /* BlueprintStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274367B51AA2B0710030C97B /* BlueprintStub.swift */; };
 		2746CDC51A702F7800719B66 /* Mockingjay.h in Headers */ = {isa = PBXBuildFile; fileRef = 2746CDC41A702F7800719B66 /* Mockingjay.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2746CDCB1A702F7800719B66 /* Mockingjay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2746CDBF1A702F7800719B66 /* Mockingjay.framework */; };
 		2746CDD21A702F7800719B66 /* MockingjayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2746CDD11A702F7800719B66 /* MockingjayTests.swift */; };
@@ -64,6 +66,8 @@
 		274367A31AA29ADA0030C97B /* URITemplate.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = URITemplate.xcodeproj; path = URITemplate/URITemplate.xcodeproj; sourceTree = "<group>"; };
 		274367AF1AA29E510030C97B /* Builders.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Builders.swift; sourceTree = "<group>"; };
 		274367B11AA29E620030C97B /* BuildersTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildersTests.swift; sourceTree = "<group>"; };
+		274367B31AA2AFF50030C97B /* Blueprint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Blueprint.swift; sourceTree = "<group>"; };
+		274367B51AA2B0710030C97B /* BlueprintStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlueprintStub.swift; sourceTree = "<group>"; };
 		2746CDBF1A702F7800719B66 /* Mockingjay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mockingjay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2746CDC31A702F7800719B66 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2746CDC41A702F7800719B66 /* Mockingjay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Mockingjay.h; sourceTree = "<group>"; };
@@ -134,6 +138,8 @@
 				274367971AA28AFC0030C97B /* Matchers.swift */,
 				274367AF1AA29E510030C97B /* Builders.swift */,
 				274367931AA27AAD0030C97B /* MockingjayProtocol.swift */,
+				274367B31AA2AFF50030C97B /* Blueprint.swift */,
+				274367B51AA2B0710030C97B /* BlueprintStub.swift */,
 				2743679B1AA28D4D0030C97B /* XCTest.swift */,
 				2743679F1AA2926D0030C97B /* XCTest.m */,
 				2746CDC21A702F7800719B66 /* Supporting Files */,
@@ -312,8 +318,10 @@
 			files = (
 				274367981AA28AFC0030C97B /* Matchers.swift in Sources */,
 				274367921AA27A7C0030C97B /* Mockingjay.swift in Sources */,
+				274367B41AA2AFF50030C97B /* Blueprint.swift in Sources */,
 				274367941AA27AAD0030C97B /* MockingjayProtocol.swift in Sources */,
 				274367B01AA29E510030C97B /* Builders.swift in Sources */,
+				274367B61AA2B0710030C97B /* BlueprintStub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Mockingjay/Blueprint.swift
+++ b/Mockingjay/Blueprint.swift
@@ -1,0 +1,249 @@
+//
+//  Blueprint.swift
+//  Representor
+//
+//  Created by Kyle Fuller on 06/01/2015.
+//  Copyright (c) 2015 Apiary. All rights reserved.
+//
+//  File borrowed from https://github.com/the-hypermedia-project/representor-swift
+//  at c431e9c9a8954115a495910fc4f5cb8cbdbb843d
+//
+
+import Foundation
+
+// MARK: Models
+
+/// A structure representing an API Blueprint AST
+public struct Blueprint {
+  /// Name of the API
+  public let name:String
+
+  /// Top-level description of the API in Markdown (.raw) or HTML (.html)
+  public let description:String?
+
+  /// The collection of resource groups
+  public let resourceGroups:[ResourceGroup]
+
+  public init(name:String, description:String?, resourceGroups:[ResourceGroup]) {
+    self.name = name
+    self.description = description
+    self.resourceGroups = resourceGroups
+  }
+
+  public init(ast:[String:AnyObject]) {
+    name = ast["name"] as String
+    description = ast["description"] as? String
+    resourceGroups = parseBlueprintResourceGroups(ast)
+  }
+
+  public init?(named:String, bundle:NSBundle? = nil) {
+    func loadFile(named:String, bundle:NSBundle) -> [String:AnyObject]? {
+      if let url = bundle.URLForResource(named, withExtension: nil) {
+        if let data = NSData(contentsOfURL: url) {
+          let object: AnyObject? = NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions(0), error: nil)
+          return object as? [String:AnyObject]
+        }
+      }
+
+      return nil
+    }
+
+    let ast = loadFile(named, bundle ?? NSBundle.mainBundle())
+    if let ast = ast {
+      self.init(ast: ast)
+    } else {
+      return nil
+    }
+  }
+}
+
+/// Logical group of resources.
+public struct ResourceGroup {
+  /// Name of the Resource Group
+  public let name:String
+
+  /// Description of the Resource Group (.raw or .html)
+  public let description:String?
+
+  /// Array of the respective resources belonging to the Resource Group
+  public let resources:[Resource]
+
+  public init(name:String, description:String?, resources:[Resource]) {
+    self.name = name
+    self.description = description
+    self.resources = resources
+  }
+}
+
+/// Description of one resource, or a cluster of resources defined by its URI template
+public struct Resource {
+  /// Name of the Resource
+  public let name:String
+
+  /// Description of the Resource (.raw or .html)
+  public let description:String?
+
+  /// URI Template as defined in RFC6570
+  // TODO, make this a URITemplate object
+  public let uriTemplate:String
+
+  /// Array of URI parameters
+  public let parameters:[Parameter]
+
+  /// Array of actions available on the resource each defining at least one complete HTTP transaction
+  public let actions:[Action]
+
+  public init(name:String, description:String?, uriTemplate:String, parameters:[Parameter], actions:[Action]) {
+    self.name = name
+    self.description = description
+    self.uriTemplate = uriTemplate
+    self.actions = actions
+    self.parameters = parameters
+  }
+}
+
+/// Description of one URI template parameter
+public struct Parameter {
+  /// Name of the parameter
+  public let name:String
+
+  /// Description of the Parameter (.raw or .html)
+  public let description:String?
+
+  /// An arbitrary type of the parameter (a string)
+  public let type:String?
+
+  /// Boolean flag denoting whether the parameter is required (true) or not (false)
+  public let required:Bool
+
+  /// A default value of the parameter (a value assumed when the parameter is not specified)
+  public let defaultValue:String?
+
+  /// An example value of the parameter
+  public let example:String?
+
+  /// An array enumerating possible parameter values
+  public let values:[String]?
+
+  public init(name:String, description:String?, type:String?, required:Bool, defaultValue:String?, example:String?, values:[String]?) {
+    self.name = name
+    self.description = description
+    self.type = type
+    self.required = required
+    self.defaultValue = defaultValue
+    self.example = example
+    self.values = values
+  }
+}
+
+// An HTTP transaction (a request-response transaction). Actions are specified by an HTTP request method within a resource
+public struct Action {
+  /// Name of the Action
+  public let name:String
+
+  /// Description of the Action (.raw or .html)
+  public let description:String?
+
+  /// HTTP request method defining the action
+  public let method:String
+
+  /// Array of URI parameters
+  public let parameters:[Parameter]
+
+  public init(name:String, description:String?, method:String, parameters:[Parameter]) {
+    self.name = name
+    self.description = description
+    self.method = method
+    self.parameters = parameters
+  }
+}
+
+// MARK: AST Parsing
+
+func compactMap<C : CollectionType, T>(source: C, transform: (C.Generator.Element) -> T?) -> [T] {
+  var collection = [T]()
+
+  for element in source {
+    if let item = transform(element) {
+      collection.append(item)
+    }
+  }
+
+  return collection
+}
+
+func parseParameter(source:[[String:AnyObject]]?) -> [Parameter] {
+  if let source = source {
+    return source.map { item in
+      let name = item["name"] as String
+      let description = item["description"] as? String
+      let type = item["type"] as? String
+      let required = item["required"] as? Bool
+      let defaultValue = item["default"] as? String
+      let example = item["example"] as? String
+      let values = item["values"] as? [String]
+      return Parameter(name: name, description: description, type: type, required: required ?? true, defaultValue: defaultValue, example: example, values: values)
+    }
+  }
+
+  return []
+}
+
+func parseActions(source:[[String:AnyObject]]?) -> [Action] {
+  if let source = source {
+    return compactMap(source) { item in
+      let name = item["name"] as? String
+      let description = item["description"] as? String
+      let method = item["method"] as? String
+      let parameters = parseParameter(item["parameters"] as? [[String:AnyObject]])
+
+      if let name = name {
+        if let method = method {
+          return Action(name: name, description: description, method: method, parameters: parameters)
+        }
+      }
+
+      return nil
+    }
+  }
+
+  return []
+}
+
+func parseResources(source:[[String:AnyObject]]?) -> [Resource] {
+  if let source = source {
+    return compactMap(source) { item in
+      let name = item["name"] as? String
+      let description = item["description"] as? String
+      let uriTemplate = item["uriTemplate"] as? String
+      let actions = parseActions(item["actions"] as? [[String:AnyObject]])
+      let parameters = parseParameter(item["parameters"] as? [[String:AnyObject]])
+
+      if let name = name {
+        if let uriTemplate = uriTemplate {
+          return Resource(name: name, description: description, uriTemplate: uriTemplate, parameters: parameters, actions: actions)
+        }
+      }
+
+      return nil
+    }
+  }
+
+  return []
+}
+
+private func parseBlueprintResourceGroups(blueprint:Dictionary<String, AnyObject>) -> [ResourceGroup] {
+  if let resourceGroups = blueprint["resourceGroups"] as? [[String:AnyObject]] {
+    return compactMap(resourceGroups) { dictionary in
+      if let name = dictionary["name"] as String? {
+        let resources = parseResources(dictionary["resources"] as? [[String:AnyObject]])
+        let description = dictionary["description"] as String?
+        return ResourceGroup(name: name, description: description, resources: resources)
+      }
+      
+      return nil
+    }
+  }
+  
+  return []
+}

--- a/Mockingjay/BlueprintStub.swift
+++ b/Mockingjay/BlueprintStub.swift
@@ -1,0 +1,21 @@
+//
+//  BlueprintStub.swift
+//  Mockingjay
+//
+//  Created by Kyle Fuller on 01/03/2015.
+//  Copyright (c) 2015 Cocode. All rights reserved.
+//
+
+import Foundation
+
+func matcher(resource:Resource, action:Action) -> Matcher {
+  if let method = HTTPMethod(rawValue: action.method) {
+    return http(method, resource.uriTemplate)
+  }
+
+  return { request in return false }
+}
+
+func builder(resource:Resource, action:Action) -> Builder {
+  return http(status: action, headers: nil, data: nil)
+}

--- a/Mockingjay/Matchers.swift
+++ b/Mockingjay/Matchers.swift
@@ -35,35 +35,21 @@ public func uri(uri:String)(request:NSURLRequest) -> Bool {
   return false
 }
 
-public enum HTTPMethod : Printable {
-  case GET
-  case POST
-  case PATCH
-  case PUT
-  case DELETE
-  case OPTIONS
-
-  public var description : String {
-    switch self {
-    case .GET:
-      return "GET"
-    case .POST:
-      return "POST"
-    case .PATCH:
-      return "PATCH"
-    case .PUT:
-      return "PUT"
-    case .DELETE:
-      return "DELETE"
-    case .OPTIONS:
-      return "OPTIONS"
-    }
-  }
+public enum HTTPMethod: String {
+  case OPTIONS = "OPTIONS"
+  case GET = "GET"
+  case HEAD = "HEAD"
+  case POST = "POST"
+  case PUT = "PUT"
+  case PATCH = "PATCH"
+  case DELETE = "DELETE"
+  case TRACE = "TRACE"
+  case CONNECT = "CONNECT"
 }
 
 public func http(method:HTTPMethod, uri:String)(request:NSURLRequest) -> Bool {
   if let requestMethod = request.HTTPMethod {
-    if requestMethod == method.description {
+    if requestMethod == method.rawValue {
       return Mockingjay.uri(uri)(request: request)
     }
   }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,28 @@ func builder(request:NSURLRequest) -> Response {
 stub(matcher, builder)
 ```
 
+## API Blueprint
+
+![API Blueprint](https://raw.githubusercontent.com/apiaryio/api-blueprint/master/assets/logo_apiblueprint.png)
+
+Mockingjay comes with complete support for the API Blueprint language. Which allows you to stub all of your requests directly from your API description.
+
+To stub all requests from an API Blueprint, you will first need to convert it into it’s AST form in JSON. For this, you can use [Snow Crash](https://github.com/apiaryio/snowcrash).
+
+```bash
+snowcrash -o palaver.apib.json -f json palaver-api-docs/palaver.apib
+```
+
+Then you can simply add the resultant JSON file into your test bundle and then load it in your tests:
+
+```swift
+func setUp() {
+  super.setUp()
+
+  let blueprint = Blueprint(named:"palaver.apib.json")
+}
+```
+
 ## License
 
 Mockingjay is licensed under the BSD license. See [LICENSE](LICENSE) for more


### PR DESCRIPTION
:warning: WORK IN PROGRESS :warning:

This pull request adds support for stubbing requests from [API Blueprint](http://apiblueprint.org/).

- [x] Add structures for Blueprint AST examples
- [x] Parsing of Blueprint AST examples
- [ ] Write basic response builder for examples using content-negotiation to determine example which example to use
- [ ] Ability to enable "exact" matching for request bodies, i-e, JSON structures need to be identical
- [ ] Allow registering a specific action via relation
- [ ] Update readme
- [ ] Pull request on apiblueprint.org