### PR TITLE
Suppress gem documentation generation on CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 before_install:
-- gem install cocoapods --pre
-- gem install xcpretty
+- gem install cocoapods --pre --no-document
+- gem install xcpretty --no-document
 script:
 - xcodebuild -project Mockingjay.xcodeproj -scheme Mockingjay test -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty -c && exit ${PIPESTATUS[0]}
 - pod lib lint --quick


### PR DESCRIPTION
These docs are unused on travis and they (slightly) increase build time.