### PR TITLE
Stub from API Blueprint

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "URITemplate"]
 	path = URITemplate
 	url = https://github.com/kylef/URITemplate.swift
+[submodule "representor-swift"]
+	path = representor-swift
+	url = https://github.com/the-hypermedia-project/representor-swift

--- a/Mockingjay.podspec
+++ b/Mockingjay.podspec
@@ -28,5 +28,10 @@ Pod::Spec.new do |spec|
     xctest_spec.source_files = 'Mockingjay/XCTest.swift'
     xctest_spec.frameworks = 'XCTest'
   end
+
+  spec.subspec 'Blueprint' do |blueprint_spec|
+    blueprint_spec.dependency 'Representor', '~> 0.3.0'
+    blueprint_spec.source_files = 'Mockingjay/Blueprint.swift'
+  end
 end
 

--- a/Mockingjay.xcodeproj/project.pbxproj
+++ b/Mockingjay.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		273E7B9C1ACA2B4E006449A1 /* Representor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 273E7B961ACA2B28006449A1 /* Representor.framework */; };
+		273E7B9E1ACA2B5D006449A1 /* Blueprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273E7B9D1ACA2B5D006449A1 /* Blueprint.swift */; };
 		274367921AA27A7C0030C97B /* Mockingjay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274367911AA27A7C0030C97B /* Mockingjay.swift */; };
 		274367941AA27AAD0030C97B /* MockingjayProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274367931AA27AAD0030C97B /* MockingjayProtocol.swift */; };
 		274367961AA27B170030C97B /* MockingjayProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274367951AA27B170030C97B /* MockingjayProtocolTests.swift */; };
@@ -23,6 +25,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		273E7B951ACA2B28006449A1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 273E7B8E1ACA2B28006449A1 /* Representor.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 770834631A0913860008869E;
+			remoteInfo = Representor;
+		};
+		273E7B971ACA2B28006449A1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 273E7B8E1ACA2B28006449A1 /* Representor.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 7708346E1A0913860008869E;
+			remoteInfo = RepresentorTests;
+		};
+		273E7B9A1ACA2B45006449A1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 273E7B8E1ACA2B28006449A1 /* Representor.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 770834621A0913860008869E;
+			remoteInfo = Representor;
+		};
 		274367A81AA29ADA0030C97B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 274367A31AA29ADA0030C97B /* URITemplate.xcodeproj */;
@@ -54,6 +77,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		273E7B8E1ACA2B28006449A1 /* Representor.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Representor.xcodeproj; path = "representor-swift/Representor.xcodeproj"; sourceTree = "<group>"; };
+		273E7B9D1ACA2B5D006449A1 /* Blueprint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Blueprint.swift; sourceTree = "<group>"; };
 		274367911AA27A7C0030C97B /* Mockingjay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mockingjay.swift; sourceTree = "<group>"; };
 		274367931AA27AAD0030C97B /* MockingjayProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockingjayProtocol.swift; sourceTree = "<group>"; };
 		274367951AA27B170030C97B /* MockingjayProtocolTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockingjayProtocolTests.swift; sourceTree = "<group>"; };
@@ -80,6 +105,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				273E7B9C1ACA2B4E006449A1 /* Representor.framework in Frameworks */,
 				274367AE1AA29AED0030C97B /* URITemplate.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -95,6 +121,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		273E7B8F1ACA2B28006449A1 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				273E7B961ACA2B28006449A1 /* Representor.framework */,
+				273E7B981ACA2B28006449A1 /* RepresentorTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		274367A41AA29ADA0030C97B /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -107,6 +142,7 @@
 		2746CDB51A702F7800719B66 = {
 			isa = PBXGroup;
 			children = (
+				273E7B8E1ACA2B28006449A1 /* Representor.xcodeproj */,
 				274367A31AA29ADA0030C97B /* URITemplate.xcodeproj */,
 				2746CDDB1A702FC100719B66 /* Configurations */,
 				2746CDC11A702F7800719B66 /* Mockingjay */,
@@ -136,6 +172,7 @@
 				274367931AA27AAD0030C97B /* MockingjayProtocol.swift */,
 				2743679B1AA28D4D0030C97B /* XCTest.swift */,
 				274367C51AA35FD00030C97B /* NSURLSessionConfiguration.swift */,
+				273E7B9D1ACA2B5D006449A1 /* Blueprint.swift */,
 				2746CDC21A702F7800719B66 /* Supporting Files */,
 			);
 			path = Mockingjay;
@@ -205,6 +242,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				273E7B9B1ACA2B45006449A1 /* PBXTargetDependency */,
 				274367AD1AA29AE70030C97B /* PBXTargetDependency */,
 			);
 			name = Mockingjay;
@@ -259,6 +297,10 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
+					ProductGroup = 273E7B8F1ACA2B28006449A1 /* Products */;
+					ProjectRef = 273E7B8E1ACA2B28006449A1 /* Representor.xcodeproj */;
+				},
+				{
 					ProductGroup = 274367A41AA29ADA0030C97B /* Products */;
 					ProjectRef = 274367A31AA29ADA0030C97B /* URITemplate.xcodeproj */;
 				},
@@ -272,6 +314,20 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		273E7B961ACA2B28006449A1 /* Representor.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Representor.framework;
+			remoteRef = 273E7B951ACA2B28006449A1 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		273E7B981ACA2B28006449A1 /* RepresentorTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = RepresentorTests.xctest;
+			remoteRef = 273E7B971ACA2B28006449A1 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		274367A91AA29ADA0030C97B /* URITemplate.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -312,6 +368,7 @@
 			files = (
 				274367981AA28AFC0030C97B /* Matchers.swift in Sources */,
 				274367921AA27A7C0030C97B /* Mockingjay.swift in Sources */,
+				273E7B9E1ACA2B5D006449A1 /* Blueprint.swift in Sources */,
 				A1E3C5701AA4EA130069C998 /* XCTest.swift in Sources */,
 				274367C61AA35FD00030C97B /* NSURLSessionConfiguration.swift in Sources */,
 				274367941AA27AAD0030C97B /* MockingjayProtocol.swift in Sources */,
@@ -333,6 +390,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		273E7B9B1ACA2B45006449A1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Representor;
+			targetProxy = 273E7B9A1ACA2B45006449A1 /* PBXContainerItemProxy */;
+		};
 		274367AD1AA29AE70030C97B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = URITemplate;

--- a/Mockingjay/Blueprint.swift
+++ b/Mockingjay/Blueprint.swift
@@ -1,0 +1,60 @@
+//
+//  XCTest.swift
+//  Mockingjay
+//
+//  Created by Kyle Fuller on 28/02/2015.
+//  Copyright (c) 2015 Cocode. All rights reserved.
+//
+
+import Representor
+import XCTest
+
+/// Extension to XCTest for API Blueprint stubbing
+extension XCTest {
+  /*** Stub an entire API Blueprint
+  :param: blueprint The given blueprint to stub
+  :param: baseURL An optional base URI for the URL matching
+  */
+  public func stub(blueprint:Blueprint, baseURL:String?) {
+    var relativeURL:NSURL?
+    if let baseURL = baseURL {
+      relativeURL = NSURL(string: baseURL)
+    }
+
+    let resources = reduce(map(blueprint.resourceGroups) { $0.resources }, [], +)
+
+    for resource in resources {
+      for action in resource.actions {
+        let url = NSURL(string: action.uriTemplate ?? resource.uriTemplate, relativeToURL: relativeURL)
+
+        func matcher(request:NSURLRequest) -> Bool {
+          if let requestMethod = request.HTTPMethod {
+            if requestMethod == action.method {
+              return uri(url!.absoluteString!)(request: request)
+            }
+          }
+
+          return false
+        }
+
+        if let example = action.examples.first {
+          // Todo content-negotiate requests
+
+          if let response = example.responses.first {
+            // Headers in the HTTP method are wrong and are a dictionary :(
+            let headers = reduce(response.headers, [String:String]()) { accumulator, header in
+              var mutaleAccumulator = accumulator
+              mutaleAccumulator[header.name] = header.value
+              return mutaleAccumulator
+            }
+
+            if let status = response.name.toInt() {
+              let builder = http(status:status, headers:headers, data:response.body)
+              stub(matcher, builder)
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Supersedes #6

### Installation (via CocoaPods)

```ruby
pod 'Mockingjay', :git => 'https://github.com/kylef/Mockingjay', :branch => 'kylef/blueprint'
```

### Usage (in XCTest subclass)

Note, requires AST form of the blueprint in the test bundle (see https://github.com/the-hypermedia-project/representor-swift/wiki/API-Blueprint).

```swift
func setUp() {
  let blueprint = Blueprint(named: "apiary.apib.json")
  stub(blueprint, "https://api.base/")
}
```

### Todo

- [ ] Refactor
- [ ] Use the `HOST` metadata as the default base URI
- [ ] Allow stubbing of individual resource, action, example
- [ ] Support for content-negotiation of requests stubs
- [ ] Ability to use JSON Schema validation of request payloads (re #14)
- [ ] Ability to "hard-match" on request bodies (for JSON, compare the JSON objects, other content types just compare the raw data)
- [ ] Allow a user to provide a custom filter block for example matching
- [ ] Update README
- [ ] Update apiblueprint.org to include Mockingjay