### PR TITLE
Remove swizzled teardown method

### DIFF
--- a/Mockingjay/XCTest.swift
+++ b/Mockingjay/XCTest.swift
@@ -6,13 +6,10 @@
 //  Copyright (c) 2015 Cocode. All rights reserved.
 //
 
-import Foundation
 import XCTest
 import Mockingjay
 
 extension XCTest {
-  // MARK: Stubbing
-
   public func stub(matcher:Matcher, builder:Builder) -> Stub {
     return MockingjayProtocol.addStub(matcher, builder: builder)
   }
@@ -22,21 +19,6 @@ extension XCTest {
   }
 
   public func removeAllStubs() {
-    MockingjayProtocol.removeAllStubs()
-  }
-
-  // MARK: Teardown
-
-  override public class func initialize() {
-    if (self === XCTest.self) {
-      let tearDown = class_getInstanceMethod(self, "tearDown")
-      let mockingjayTearDown = class_getInstanceMethod(self, "mockingjayTearDown")
-      method_exchangeImplementations(tearDown, mockingjayTearDown)
-    }
-  }
-
-  func mockingjayTearDown() {
-    mockingjayTearDown()
     MockingjayProtocol.removeAllStubs()
   }
 }


### PR DESCRIPTION
- Swizzling the teardown method interferes with other frameworks trying to do the same (eg. KIF) and I'd rather control when to remove stubs myself.
- Remove unnecessary Foundation import