### PR TITLE
Disable Bitcode in XCTest

### DIFF
--- a/Mockingjay.podspec
+++ b/Mockingjay.podspec
@@ -27,6 +27,7 @@ Pod::Spec.new do |spec|
     xctest_spec.dependency 'Mockingjay/Core'
     xctest_spec.source_files = 'Mockingjay/XCTest.swift'
     xctest_spec.frameworks = 'XCTest'
+    xctest_spec.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
   end
 end
 


### PR DESCRIPTION
XCTest doesn't support Bitcode at the moment, so to avoid getting a linker error when building for a real device I have disabled Bitcode.