### PR TITLE
Add `Cartfile` for full Carthage support

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "kylef/URITemplate.swift" ~> 1.3


### PR DESCRIPTION
Right now, using Mockingjay through Carthage requires this:

```
github "kylef/Mockingjay"
github "kylef/URITemplate.swift"
```

`URITemplate.swift` being a `Mockingjay` dependency.

This PR allows `Mockingjay` for full Carthage integration by adding `URITemplate.swift` as a Carthage dependency in the main repository. Now, whenever you do this:

```
github "kylef/Mockingjay"
```

Carthage will take care of inspecting `Mockingjay`'s  `Cartfile` whenever fetched, and will resolve `URITemplate.swift` automatically.
