### PR TITLE
Fixed SteamContent support in Swift 3.0

### DIFF
--- a/Mockingjay.xcodeproj/project.pbxproj
+++ b/Mockingjay.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2705946B1C4FA7A6002A3AA9 /* MockingjayXCTestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2705946A1C4FA7A6002A3AA9 /* MockingjayXCTestTests.swift */; };
+		2715FACF1D8C81AB00A89DF7 /* URITemplate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2715FAC91D8C818C00A89DF7 /* URITemplate.framework */; };
 		274367921AA27A7C0030C97B /* Mockingjay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274367911AA27A7C0030C97B /* Mockingjay.swift */; };
 		274367941AA27AAD0030C97B /* MockingjayProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274367931AA27AAD0030C97B /* MockingjayProtocol.swift */; };
 		274367961AA27B170030C97B /* MockingjayProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274367951AA27B170030C97B /* MockingjayProtocolTests.swift */; };
@@ -22,7 +23,6 @@
 		27703A631CE2560600194732 /* MockingjayURLSessionConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 27703A621CE2560600194732 /* MockingjayURLSessionConfiguration.m */; };
 		444EA6091C5261DE000C3A9F /* MockingjayAsyncProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444EA6081C5261DE000C3A9F /* MockingjayAsyncProtocolTests.swift */; };
 		444EA60C1C52666D000C3A9F /* TestAudio.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 444EA60B1C52666D000C3A9F /* TestAudio.m4a */; };
-		44B5576C1D92CD7100320355 /* URITemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44B5576B1D92CD7100320355 /* URITemplate.swift */; };
 		A1E3C5701AA4EA130069C998 /* XCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2743679B1AA28D4D0030C97B /* XCTest.swift */; };
 /* End PBXBuildFile section */
 
@@ -88,7 +88,6 @@
 		27703A621CE2560600194732 /* MockingjayURLSessionConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockingjayURLSessionConfiguration.m; sourceTree = "<group>"; };
 		444EA6081C5261DE000C3A9F /* MockingjayAsyncProtocolTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockingjayAsyncProtocolTests.swift; sourceTree = "<group>"; };
 		444EA60B1C52666D000C3A9F /* TestAudio.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = TestAudio.m4a; sourceTree = "<group>"; };
-		44B5576B1D92CD7100320355 /* URITemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = URITemplate.swift; path = URITemplate/Sources/URITemplate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2715FACF1D8C81AB00A89DF7 /* URITemplate.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,7 +125,6 @@
 			isa = PBXGroup;
 			children = (
 				2715FABD1D8C818C00A89DF7 /* URITemplate.xcodeproj */,
-				44B5576B1D92CD7100320355 /* URITemplate.swift */,
 				2746CDDB1A702FC100719B66 /* Configurations */,
 				2746CDC11A702F7800719B66 /* Mockingjay */,
 				2746CDCE1A702F7800719B66 /* MockingjayTests */,
@@ -358,7 +357,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				44B5576C1D92CD7100320355 /* URITemplate.swift in Sources */,
 				274367981AA28AFC0030C97B /* Matchers.swift in Sources */,
 				27703A631CE2560600194732 /* MockingjayURLSessionConfiguration.m in Sources */,
 				274367921AA27A7C0030C97B /* Mockingjay.swift in Sources */,

--- a/Mockingjay.xcodeproj/project.pbxproj
+++ b/Mockingjay.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		2705946B1C4FA7A6002A3AA9 /* MockingjayXCTestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2705946A1C4FA7A6002A3AA9 /* MockingjayXCTestTests.swift */; };
-		2715FACF1D8C81AB00A89DF7 /* URITemplate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2715FAC91D8C818C00A89DF7 /* URITemplate.framework */; };
 		274367921AA27A7C0030C97B /* Mockingjay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274367911AA27A7C0030C97B /* Mockingjay.swift */; };
 		274367941AA27AAD0030C97B /* MockingjayProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274367931AA27AAD0030C97B /* MockingjayProtocol.swift */; };
 		274367961AA27B170030C97B /* MockingjayProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274367951AA27B170030C97B /* MockingjayProtocolTests.swift */; };
@@ -23,6 +22,7 @@
 		27703A631CE2560600194732 /* MockingjayURLSessionConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 27703A621CE2560600194732 /* MockingjayURLSessionConfiguration.m */; };
 		444EA6091C5261DE000C3A9F /* MockingjayAsyncProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444EA6081C5261DE000C3A9F /* MockingjayAsyncProtocolTests.swift */; };
 		444EA60C1C52666D000C3A9F /* TestAudio.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 444EA60B1C52666D000C3A9F /* TestAudio.m4a */; };
+		44B5576C1D92CD7100320355 /* URITemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44B5576B1D92CD7100320355 /* URITemplate.swift */; };
 		A1E3C5701AA4EA130069C998 /* XCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2743679B1AA28D4D0030C97B /* XCTest.swift */; };
 /* End PBXBuildFile section */
 
@@ -88,6 +88,7 @@
 		27703A621CE2560600194732 /* MockingjayURLSessionConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockingjayURLSessionConfiguration.m; sourceTree = "<group>"; };
 		444EA6081C5261DE000C3A9F /* MockingjayAsyncProtocolTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockingjayAsyncProtocolTests.swift; sourceTree = "<group>"; };
 		444EA60B1C52666D000C3A9F /* TestAudio.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = TestAudio.m4a; sourceTree = "<group>"; };
+		44B5576B1D92CD7100320355 /* URITemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = URITemplate.swift; path = URITemplate/Sources/URITemplate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,7 +96,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2715FACF1D8C81AB00A89DF7 /* URITemplate.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +125,7 @@
 			isa = PBXGroup;
 			children = (
 				2715FABD1D8C818C00A89DF7 /* URITemplate.xcodeproj */,
+				44B5576B1D92CD7100320355 /* URITemplate.swift */,
 				2746CDDB1A702FC100719B66 /* Configurations */,
 				2746CDC11A702F7800719B66 /* Mockingjay */,
 				2746CDCE1A702F7800719B66 /* MockingjayTests */,
@@ -357,6 +358,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				44B5576C1D92CD7100320355 /* URITemplate.swift in Sources */,
 				274367981AA28AFC0030C97B /* Matchers.swift in Sources */,
 				27703A631CE2560600194732 /* MockingjayURLSessionConfiguration.m in Sources */,
 				274367921AA27A7C0030C97B /* Mockingjay.swift in Sources */,

--- a/Mockingjay/Matchers.swift
+++ b/Mockingjay/Matchers.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import URITemplate
 
 // Collection of generic matchers
 

--- a/Mockingjay/Matchers.swift
+++ b/Mockingjay/Matchers.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import URITemplate
 
 // Collection of generic matchers
 

--- a/Mockingjay/MockingjayProtocol.swift
+++ b/Mockingjay/MockingjayProtocol.swift
@@ -148,7 +148,7 @@ public class MockingjayProtocol: URLProtocol {
         return
       }
       
-      let subdata = data.subdata(in: offset ..< offset)
+      let subdata = data.subdata(in: offset ..< (offset + length))
       self.client?.urlProtocol(self, didLoad: subdata)
       Thread.sleep(forTimeInterval: 0.01)
       self.download(data, fromOffset: offset + length, withMaxLength: maxLength)
@@ -163,7 +163,7 @@ public class MockingjayProtocol: URLProtocol {
       Int(str)!
     })
     let loc = range[0]
-    let length = range[1] - loc + 1
+    let length = range[1] + 1
     return loc ..< length
   }
   

--- a/Mockingjay/MockingjayProtocol.swift
+++ b/Mockingjay/MockingjayProtocol.swift
@@ -175,13 +175,15 @@ public class MockingjayProtocol: URLProtocol {
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         return
       }
+    
+      let fullLength = data.count
       data = data.subdata(in: range)
       
       //Attach new headers to response
       if let r = response as? HTTPURLResponse {
         var header = r.allHeaderFields as! [String:String]
         header["Content-Length"] = String(data.count)
-        header["Content-Range"] = "bytes \(range.lowerBound)-\(range.upperBound)/\(range.lowerBound + range.upperBound)"
+        header["Content-Range"] = "bytes \(range.lowerBound)-\(range.upperBound)/\(fullLength)"
         response = HTTPURLResponse(url: r.url!, statusCode: r.statusCode, httpVersion: nil, headerFields: header)!
       }
       

--- a/MockingjayTests/MockingjayAsyncProtocolTests.swift
+++ b/MockingjayTests/MockingjayAsyncProtocolTests.swift
@@ -105,8 +105,8 @@ class MockingjayAsyncProtocolTests: XCTestCase, URLSessionDataDelegate  {
     let dataTask = urlSession.dataTask(with: request)
     dataTask.resume()
     
-    let mutableData = NSMutableData()
-    while mutableData.length < length {
+    var mutableData = Data()
+    while mutableData.count < length {
       let expectation = self.expectation(description: "testProtocolCanReturnedDataInChunks")
       self.didReceiveDataHandler = { (session: Foundation.URLSession, dataTask: URLSessionDataTask, data: Data) in
         mutableData.append(data)
@@ -114,7 +114,9 @@ class MockingjayAsyncProtocolTests: XCTestCase, URLSessionDataDelegate  {
       }
       waitForExpectations(timeout: 2.0, handler: nil)
     }
-//    XCTAssertEqual(mutableData, data.subdata(in: NSMakeRange(50000, length)))
+    
+    let correctData = data.subdata(in: 50000 ..< (50000 + length))
+    XCTAssertEqual(mutableData, correctData)
   }
   
   // MARK: NSURLSessionDataDelegate

--- a/MockingjayTests/MockingjayProtocolTests.swift
+++ b/MockingjayTests/MockingjayProtocolTests.swift
@@ -12,6 +12,14 @@ import Mockingjay
 
 
 class MockingjayProtocolTests : XCTestCase {
+  
+  var urlSession:URLSession!
+  
+  override func setUp() {
+    super.setUp()
+    urlSession = URLSession(configuration: URLSessionConfiguration.default)
+  }
+  
   override func tearDown() {
     super.tearDown()
     MockingjayProtocol.removeAllStubs()
@@ -49,17 +57,23 @@ class MockingjayProtocolTests : XCTestCase {
     }
 
     var response: URLResponse?
-    var error: NSError?
+    var error:Error?
     var data: Data? = nil
-    do {
-      data = try NSURLConnection.sendSynchronousRequest(request, returning: &response)
-    } catch let error1 as NSError {
-      error = error1
+    
+    let expectation = self.expectation(description: "testProtocolReturnsErrorWithRegisteredStubError")
+    let dataTask = urlSession.dataTask(with: request) { (d, r, e) in
+      response = r
+      data = d
+      error = e
+      expectation.fulfill()
     }
-
+    dataTask.resume()
+    waitForExpectations(timeout: 2.0, handler: nil)
+    
     XCTAssertNil(response)
     XCTAssertNil(data)
-    XCTAssertEqual(error!.domain, "MockingjayTests")  }
+    XCTAssertNotNil(error)
+  }
 
   func testProtocolReturnsResponseWithRegisteredStubError() {
     let request = URLRequest(url: URL(string: "https://kylefuller.co.uk/")!)
@@ -71,13 +85,25 @@ class MockingjayProtocolTests : XCTestCase {
     }) { (request) -> (Response) in
         return Response.success(stubResponse, .content(stubData))
     }
-
+    
     var response:URLResponse?
-    let data = try? NSURLConnection.sendSynchronousRequest(request, returning: &response)
+    var data:Data?
+    var error:Error?
+
+    let expectation = self.expectation(description: "testProtocolReturnsResponseWithRegisteredStubError")
+    let dataTask = urlSession.dataTask(with: request) { (d, r, e) in
+      response = r
+      data = d
+      error = e
+      expectation.fulfill()
+    }
+    dataTask.resume()
+    waitForExpectations(timeout: 2.0, handler: nil)
 
     XCTAssertEqual(response?.url, stubResponse.url!)
     XCTAssertEqual(response?.textEncodingName, "utf-8")
     XCTAssertEqual(data, stubData)
+    XCTAssertNil(error)
   }
 
   func testProtocolReturnsResponseWithLastRegisteredMatchinbgStub() {
@@ -99,11 +125,23 @@ class MockingjayProtocolTests : XCTestCase {
     }
 
     var response:URLResponse?
-    let data = try? NSURLConnection.sendSynchronousRequest(request, returning: &response)
+    var data:Data?
+    var error:Error?
+    
+    let expectation = self.expectation(description: "testProtocolReturnsResponseWithRegisteredStubError")
+    let dataTask = urlSession.dataTask(with: request) { (d, r, e) in
+      response = r
+      data = d
+      error = e
+      expectation.fulfill()
+    }
+    dataTask.resume()
+    waitForExpectations(timeout: 2.0, handler: nil)
 
     XCTAssertEqual(response?.url, stubResponse.url!)
     XCTAssertEqual(response?.textEncodingName, "utf-8")
     XCTAssertEqual(data, stub2Data)
+    XCTAssertNil(error)
   }
   
 }


### PR DESCRIPTION
Hello, I saw you were working on a Swift 3.0 branch, I noticed the tests weren't passing, so just added a few fixes to the bits of code I contributed for Swift 3.0. Also removed support for NSURLConnection in favour of URLSession to remove compiler warnings.
