### PR TITLE
Fix ambiguous XCTest.tearDown swizzle

### DIFF
--- a/Sources/Mockingjay/XCTest.swift
+++ b/Sources/Mockingjay/XCTest.swift
@@ -10,7 +10,7 @@ import ObjectiveC
 import XCTest
 
 let swizzleTearDown: Void = {
-  let tearDown = class_getInstanceMethod(XCTest.self, #selector(XCTest.tearDown))
+  let tearDown = class_getInstanceMethod(XCTest.self, #selector(XCTest.tearDown as (XCTest) -> () -> Void))
   let mockingjayTearDown = class_getInstanceMethod(XCTest.self, #selector(XCTest.mockingjayTearDown))
   method_exchangeImplementations(tearDown!, mockingjayTearDown!)
 }()


### PR DESCRIPTION
This PR addresses an issue occurring with Xcode 13 that prevents this project from building.

Xcode has trouble determining which `XCTest.tearDown` is referred to, the class or the instance method. As an alternative I initially suggested `Selector("tearDown")` which will use the instance method and resolve the issue. However, for that change Xcode displays a warning, and suggests the change in this PR as an alternative.

I have tested the change on Xcode 13 and an old Xcode 12.2 beta, on both it compiles and tests pass.

Closes #119